### PR TITLE
Allow other mina commands to be run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,5 @@ RUN gem install mina-circle -v '~> 2.0.1'
 RUN gem install mina-rollbar -v '~> 0.1.6'
 RUN gem install dotenv
 
-ENTRYPOINT ["mina", "deploy"]
+ENTRYPOINT ["mina"]
+CMD ["help"]


### PR DESCRIPTION
When the mina command "deploy" is included in the entrypoint, it's not
easy to run other commands like `init` or `help`. By moving the mina
command down to a docker `CMD`.

## How to test

1. Pull down this branch
2. `docker build -t sparkbox/mina-deploy:local .`
3. `docker run sparkbox/mina-deploy:local`
4. *_Verify_*: The help information is output
5. `docker run sparkbox/mina-deploy:local ssh`
6. *_Verify_*: _Mina::Error: Setting :domain is not set_ is output showing we've attempted the `ssh` command.