### PR TITLE
Mina 1.2 along with mina-circle 3 beta

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ FROM ruby:2.5
 
 WORKDIR deploy
 
-RUN gem install mina -v '~> 0.3'
-RUN gem install mina-circle -v '~> 2.0.1'
-RUN gem install mina-rollbar -v '~> 0.1.6'
+RUN gem install mina -v '~> 1.2'
+RUN gem install mina-circle -v '~> 3.0.0.beta.1'
+RUN gem install mina-rollbar -v '~> 1.0.1'
 RUN gem install dotenv
 
 ENTRYPOINT ["mina"]
-CMD ["help"]
+CMD ["--help"]


### PR DESCRIPTION
Upgrades mina to 1.2 and corresponding updates to mina-circle 3.0.0.beta.1

**To test:**

1. `docker build -t sparkbox/mina-deploy:local .` will build a local instance of `mina-deploy`.
2. Run `docker run -it --rm sparkbox/mina-deploy:local`
3. [ ] Ensure you see the `--help` output which should include `mina [-f rakefile] {options} targets...` and the option flags list.
4. Run `docker run -it --rm sparkbox/mina-deploy:local --version`
5. [ ] Ensure you see `Mina, version v1.2.3`
6. Run `docker run -it --rm sparkbox/mina-deploy:local --tasks`
7. [ ] Ensure you see `mina init  # Creates a sample config file`
8. Run `docker run -it --rm -v ${PWD}:/deploy sparkbox/mina-deploy:local init`
9. [ ] You should now have a `config/deploy.rb` file

You can delete the `config/deploy.rb` file when you're done.

**Docker Image:** I've also configured [automatic image builds on Docker Hub](https://hub.docker.com/repository/docker/sparkbox/mina-deploy/builds). When this is merged, the `latest` Docker image for mina-deploy will be built and published. We'll also want to publish a 2.0.0 tag of this repository so that folks can depend directly on this version of mina-deploy.

* [ ] Publish 2.0.0 tag to Github.
